### PR TITLE
don't update_range without query

### DIFF
--- a/lua/ts-rainbow/strategy/global.lua
+++ b/lua/ts-rainbow/strategy/global.lua
@@ -42,6 +42,7 @@ local function update_range(bufnr, changes, tree, lang)
 	if vim.fn.pumvisible() ~= 0 or not lang then return end
 
 	local query = lib.get_query(lang)
+	if not query then return end
 	local matches = Stack.new()
 
 	for _, change in ipairs(changes) do


### PR DESCRIPTION
Fixes this bug:
![WindowsTerminal_otYNITFOHJ](https://user-images.githubusercontent.com/118403/224103342-e4713fb3-9a79-47d6-a2af-1d3133d3cca1.png)

I'm not sure what causes this, but here it happens when I tried to add a comment, after I typed the space behind `--`.