### PR TITLE
Add fennel queries and tests

### DIFF
--- a/queries/fennel/rainbow-parens.scm
+++ b/queries/fennel/rainbow-parens.scm
@@ -1,0 +1,48 @@
+(list
+  "(" @opening
+  ")" @closing) @container
+
+(table
+  "{" @opening
+  (":" @intermediate)?
+  "}" @closing) @container
+
+(sequential_table
+  "[" @opening
+  "]" @closing) @container
+
+(fn
+  "(" @opening
+   ")" @closing) @container
+
+(lambda
+  "(" @opening
+   ")" @closing) @container
+
+(let
+  "(" @opening
+  ")" @closing) @container
+
+(set
+  "(" @opening
+  ")" @closing) @container
+
+(each
+  "(" @opening
+  ")" @closing) @container
+
+(for
+  "(" @opening
+  ")" @closing) @container
+
+(icollect
+  "(" @opening
+  ")" @closing) @container
+
+(collect
+  "(" @opening
+  ")" @closing) @container
+
+(accumulate
+  "(" @opening
+  ")" @closing) @container

--- a/test/highlight/fennel/regular.fnl
+++ b/test/highlight/fennel/regular.fnl
@@ -1,0 +1,38 @@
+(print (.. "foo" "bar"))
+
+{ :a { :b { :c { :d {} } } } }
+
+[0 [1 [2 [3 []]]]]
+
+(fn add-partial [x]
+  (fn [y]
+    (fn [z] (+ x y z))))
+
+(λ sub-partial [x]
+   (λ [y]
+      (λ [z] (- x y z))))
+
+(let [a 1]
+  (let [b 2]
+    (let [c 3]
+      (+ a b c))))
+
+(let [t {:a 4 :b 8}]
+  (set t.a 2) t)
+
+(each [key value (pairs {"a" 1 "b" 2})]
+  (print key value))
+
+(for [i 1 10]
+  (print i))
+
+(var numbers [1 2 3 4 5 6])
+
+(icollect [_ x (ipairs numbers)]
+  (+ x 1))
+
+(collect [_ x (ipairs numbers)]
+  (values x true))
+
+(accumulate [acc 0 _ x (ipairs numbers)]
+  (+ acc x))


### PR DESCRIPTION
I added a query for pretty much any expression capable of creating opening a local scope, which means this definitely does more than the rest of the currently supported lisp dialects. I have no objections to trimming the queries down to just the basic data structures, although I'd argue to keep `fn`/`lambda` for parity with [common lisp](https://github.com/HiPhish/nvim-ts-rainbow2/blob/3393981bd091d3ebeec7476075dbce6b5ea9d317/queries/commonlisp/rainbow-parens.scm#LL6C4-L6C4) and `let` as a very common form.