### PR TITLE
fix(highlight): remove previous highlights before applying new ones

### DIFF
--- a/lua/ts-rainbow/internal.lua
+++ b/lua/ts-rainbow/internal.lua
@@ -87,7 +87,11 @@ function M.detach(bufnr)
 	else
 		vim.api.nvim_set_hl(0, "@punctuation.bracket", { link = "TSPunctBracket" })
 	end
-	vim.api.nvim_buf_clear_namespace(bufnr, lib.nsid, 0, -1)
+
+	-- Clear all the namespaces for each language
+	lib.buffers[bufnr].parser:for_each_child(function(_, lang)
+		lib.clear_namespace(bufnr, lang)
+	end)
 
 	-- For now we silently discard errors, but in the future we should log
 	-- them.

--- a/lua/ts-rainbow/strategy/global.lua
+++ b/lua/ts-rainbow/strategy/global.lua
@@ -46,6 +46,10 @@ local function update_range(bufnr, changes, tree, lang)
 
 	for _, change in ipairs(changes) do
 		local root_node = tree:root()
+		local capture_extmarks = vim.api.nvim_buf_get_extmarks(bufnr, lib.nsid, {change[1], 0}, {change[3] + 1, 0}, {})
+		for _, extmark in ipairs(capture_extmarks) do
+			vim.api.nvim_buf_del_extmark(bufnr, lib.nsid, extmark[1])
+		end
 		for _, match, _ in query:iter_matches(root_node, bufnr, change[1], change[3] + 1) do
 			-- This is the match record, it lists all the relevant nodes from
 			-- the match.

--- a/lua/ts-rainbow/strategy/global.lua
+++ b/lua/ts-rainbow/strategy/global.lua
@@ -46,10 +46,7 @@ local function update_range(bufnr, changes, tree, lang)
 
 	for _, change in ipairs(changes) do
 		local root_node = tree:root()
-		local capture_extmarks = vim.api.nvim_buf_get_extmarks(bufnr, lib.nsid, {change[1], 0}, {change[3] + 1, 0}, {})
-		for _, extmark in ipairs(capture_extmarks) do
-			vim.api.nvim_buf_del_extmark(bufnr, lib.nsid, extmark[1])
-		end
+		vim.api.nvim_buf_clear_namespace(bufnr, lib.nsid, change[1], change[3] + 1)
 		for _, match, _ in query:iter_matches(root_node, bufnr, change[1], change[3] + 1) do
 			-- This is the match record, it lists all the relevant nodes from
 			-- the match.

--- a/lua/ts-rainbow/strategy/global.lua
+++ b/lua/ts-rainbow/strategy/global.lua
@@ -23,13 +23,13 @@ local ts    = vim.treesitter
 ---Strategy which highlights the entire buffer.
 local M = {}
 
-local function highlight_matches(bufnr, matches, level)
+local function highlight_matches(bufnr, lang, matches, level)
 	local hlgroup = lib.hlgroup_at(level)
 	for _, match in matches:iter() do
-		for _, opening      in match.opening:iter()      do lib.highlight(bufnr, opening,      hlgroup) end
-		for _, closing      in match.closing:iter()      do lib.highlight(bufnr, closing,      hlgroup) end
-		for _, intermediate in match.intermediate:iter() do lib.highlight(bufnr, intermediate, hlgroup) end
-		highlight_matches(bufnr, match.children, level + 1)
+		for _, opening      in match.opening:iter()      do lib.highlight(bufnr, lang, opening,      hlgroup) end
+		for _, closing      in match.closing:iter()      do lib.highlight(bufnr, lang, closing,      hlgroup) end
+		for _, intermediate in match.intermediate:iter() do lib.highlight(bufnr, lang, intermediate, hlgroup) end
+		highlight_matches(bufnr, lang, match.children, level + 1)
 	end
 end
 
@@ -46,7 +46,7 @@ local function update_range(bufnr, changes, tree, lang)
 
 	for _, change in ipairs(changes) do
 		local root_node = tree:root()
-		vim.api.nvim_buf_clear_namespace(bufnr, lib.nsid, change[1], change[3] + 1)
+		lib.clear_namespace(bufnr, lang, change[1], change[3] + 1)
 		for _, match, _ in query:iter_matches(root_node, bufnr, change[1], change[3] + 1) do
 			-- This is the match record, it lists all the relevant nodes from
 			-- the match.
@@ -76,7 +76,7 @@ local function update_range(bufnr, changes, tree, lang)
 		end
 	end
 
-	highlight_matches(bufnr, matches, 1)
+	highlight_matches(bufnr, lang, matches, 1)
 end
 
 ---Update highlights for every tree in given buffer.

--- a/test/stress/markdown/lorem-ipsum.md
+++ b/test/stress/markdown/lorem-ipsum.md
@@ -1,0 +1,155 @@
+# Lorem Ipsum stress test
+
+This is a large Markdown file with other languages injected.
+
+```lua
+print 'This is an injected language'
+print({{{{{{{}}}}}}})
+```
+
+## Cupit Phoce sonus
+
+Lorem markdownum acernas. **Ignis ore amplius** dixit, supremumque miserere
+vinoque peti tendit plebe ergo aguntur gerere expulsa, post loca sinebat. Nostra
+minor comas saevit; quos rerum de ipsa, est bis [semine](http://caede.com/)
+Saturnia saepius flet, sim. Antro remis patet genitam pariterque ipsum dum socia
+vicit, tu nocens sororum? Hippomenes momentaque solusque Minyis
+[Deucalion](http://anus.org/nec-tellus) aevo poena, voces instant consorte
+fraternos occiderat tangit posita solo vellera me sanguis!
+
+```vim
+echo 'This is an injected language'
+echo str([[[[[[[[[]]]]]]]]])
+```
+
+Fata quae: **falsi**: pares dea [agmine
+hospite](http://www.quo-retro.net/sublimis) catenas? [Morte](http://corpus.net/)
+ad putes. Dicentem Chariclo vidit!
+
+```c
+puts("This is an injected language")
+{
+    {
+        {
+            {
+                {
+                    return ((((((2)))))) + ((((3))))
+                }
+            }
+        }
+    }
+}
+```
+
+> Delius irascere cuncti Argolis, femineis **ubi est** relatis Tityos supple
+> alebat excusat animalia. Qua licet gentem laniaverat vidit Chromin: ut Thracum
+> Lacedaemoniumque parantur tribuitque. Nec Acoete rogat satis gramine: mollibus
+> regis, sermonibus deus, lumina at.
+
+```python
+print('This is an injected language')
+print([[[[[[[[]]]]]]]])
+```
+
+## Silentia foret
+
+Requievit eventuque sociis ordine ebur referam iussam accessit temperie in
+fugant nymphas te ramos puellas, per. Posse per ait pressa dammas. Quam proximus
+scopulum sonanti accensus ab *auras* nostra ambo forte medicina repulsa et quae
+occuluere et.
+
+```bash
+echo 'This is an injected language'
+echo $(echo $(echo $(echo $(echo 'test'))))
+````
+
+Aliquam sem et tortor consequat id porta. Lectus urna duis convallis convallis
+tellus id interdum velit. Diam volutpat commodo sed egestas egestas fringilla
+phasellus. Amet commodo nulla facilisi nullam vehicula ipsum a arcu cursus. Ac
+turpis egestas maecenas pharetra convallis posuere morbi. Facilisis volutpat
+est velit egestas dui id ornare arcu. Lacus sed turpis tincidunt id aliquet. Et
+netus et malesuada fames ac turpis egestas sed tempus. Cursus in hac habitasse
+platea. Lectus proin nibh nisl condimentum id.
+
+
+```json
+[[[[[[[[["This is an injected language"]]]]]]]]]
+```
+
+Pictos excipiunt saxea. Equorum esse fac iactatis resolvit fumantis tota faveas
+ortu imago insanis. Nil Typhoea ramis timido teneris nunc septem, vale furor.
+
+```html
+<div>
+    <div>
+        <div>
+            <div>
+                <div>
+                    <p>This is an injected language</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+```
+
+1. Cadmeides condi Pelagonaque manibus petit moderator sua
+2. Et absumere dextera rediit
+3. Suis priorum dixit flendo
+4. Sic contingit mihi
+5. Nec tenet adsiduis tua vidit invitaque caeli
+
+```css
+@media (not (color)) {
+	.foo {
+		color: #ffffff;
+	}
+}
+```
+
+Sternentem raptamque meam requiret retentis et natum et, quoque, at tamen
+peccasse *manet*. Tamen cuius, increpat solvunt meritum tibi veniente
+semihomines ligo corpus de arma fata!
+
+```javascript
+console.log('This is an injected language')
+console.log(1 + (2 + (3 + (4 + (5 + (6 + (7 + (8 + 9))))))))
+```
+
+## Aliquam sub nulla tandem movere oscula pulcherrima
+
+In Cybeleia mearum illos est, superest viscera fugienti fabula Thisbes agros.
+Cum nepotem quae aurum qua abest harundine, caput et noverca!
+
+Caelum fore domus nox noxque bello Tempe erat ruent perstant te prope. Bis illis
+ea maritum, pro est ferrum mihi ictu Cyllenius. Rogat ad et sed taedae Iphis, et
+ad sinus afueram? Huc umbras: **asper iuro postquam**: ordine dum qualia diro
+equorum nisi atque!
+
+    ntfs_party_memory.graphicPortalMask(drive_tween, infringementCompression);
+    brouterHard = thinFios;
+    arp.pppEpsUnmount -= refresh.wavelength(compression(wiki, 5), serverIpv) +
+            room.paper(kindleLeopardBarcraft, gigo) + serial;
+
+Et opem primitias sine agrestes, me puto illo cum puer. Loca aptabat sed munera
+crede, quem **veris volubilibus maximus** Desierat
+[lanificae](http://natacognatas.net/ut-plus.php) inponit *pars* paratas est
+anser. Tremoribus iste [furit](http://ira.net/)! Alis potiere praedelassat
+increvit Cytherea, mediis in modo mitissima ad feto amavit. [Moenia
+illo](http://www.estygius.net/nisi.php) ille, ars ramis alis tamen mihi iste
+Naupliades et diu molles ultro agendo ire nullo.
+
+> Vicimus locuturo, quod [pars](http://www.idomeneus.org/unus) iam hunc
+> lacusque, toto. Partes **per** nec latuisse nullus isto dolore iungimus nervi.
+> Illic vult cucurri, capit digitis longus nymphaeque plagis viribus virgae,
+> ascendere sederunt urbs, aspergine trunca. Frigus [Leucothoen
+> adsiduae](http://non.org/) duos; quae dari est Amorque domuisse proles
+> quaerenti **haec**.
+
+Ac rebus merentem, portas, eandem dea versos [laborum ab
+posse](http://lignumsuccessibus.io/postquam) in mirata ad. Chirona terras;
+aether morer proelia accedere, praesagaque avido clavae vestra, tamen. Vocas
+Quirini sanguine insignia, aemula mea nomen [credere](http://pennas.io/); non
+possit primoque bisque. Omni dea vultus, huc prodierat auras de per vel despice
+retro aut. Aut generum timore, nam succedit, in sui Hector ramos loquuntur,
+naias, traiecit.


### PR DESCRIPTION
This PR adds the changes from https://github.com/mrjones2014/nvim-ts-rainbow/pull/11

Without the changes in this PR, deleting+reinserting a bracket confuses the color matching resulting in
matching pairs having different colors.

recording of the behavior with the latest version of this plugin:

[original_ts_rainbow.webm](https://user-images.githubusercontent.com/37650823/232252514-22167893-1622-40fe-9f33-189cb5ba372b.webm)

recording of the behavior with my changes:

[fixed_ts_rainbow.webm](https://user-images.githubusercontent.com/37650823/232252337-936d176c-c29b-47bd-8ade-b5a58f4feafc.webm)

One issue I found with these changes that are also present in  https://github.com/mrjones2014/nvim-ts-rainbow/pull/11 (but not the current state of this repo) is if pairs are followed by a comment (~~in rust specifically, doesn't appear to affect other languages~~ it is affecting all languages actually) the pairs will have no highlighting until you update the line:

[fixed_ts_with_trailing_comment.webm](https://user-images.githubusercontent.com/37650823/232252591-fb5e9fea-fc45-4542-82ac-8f8571997ef1.webm)

I'd be happy to look in to fixing that as well, and plan on doing so, but if you have any ideas as to what might be
causing that and where to look it would be appreciated.