### PR TITLE
Highlight only tag names in jsx

### DIFF
--- a/queries/tsx/rainbow-tags.scm
+++ b/queries/tsx/rainbow-tags.scm
@@ -1,8 +1,11 @@
 ; inherits: typescript
 
 (jsx_element
-  open_tag: (jsx_opening_element) @opening
-  close_tag: (jsx_closing_element) @closing) @container
+  open_tag: (jsx_opening_element name: (identifier) @opening)
+  close_tag: (jsx_closing_element name: (identifier) @closing)) @container
+
+(jsx_self_closing_element
+  name: (identifier) @opening @closing) @container
 
 (jsx_expression
   "{" @opening


### PR DESCRIPTION
Hi! First of all, thank you for this plugin! I couldn't live without it since I started diving into common lisp.

Then I decided to use it for typescript as well and noticed that you have separate queries for jsx tags. But it highlights the whole tag, from `<` all the way to `>`. It's a bit problematic, because this way you lose all other highlighting:

![before](https://github.com/HiPhish/nvim-ts-rainbow2/assets/3524621/8b2ee55f-9a62-4146-ba84-06ed25c7eb77)

Note that `display: flex` and `href="..."` are highlighted entirely in blue and green respectively. And if you also have functions in jsx attributes it's an even bigger problem. So I thought it would make more sense to highlight only tag names, so here's the result with my changes applied:

![after](https://github.com/HiPhish/nvim-ts-rainbow2/assets/3524621/f4820509-fdb7-426b-9d68-3d2cbfb21ca5)

But also I'm not sure if it makes sense to have the default queries that highlight only angle brackets, because I can't imagine how you nest them and why that can be useful. For me it makes more sense for this queries to be the default option, but may be I'm missing something.

If any of this is ok, I would make similar changes for html and may be we could figure out better default solution for jsx in javascript as well.

What do you think?