### PR TITLE
TypeScript: add a query for type argument brackets

### DIFF
--- a/queries/typescript/rainbow-parens.scm
+++ b/queries/typescript/rainbow-parens.scm
@@ -1,5 +1,9 @@
 ; inherits: javascript
 
+(type_arguments
+  "<" @opening
+  ">" @closing) @container
+
 (type_parameters
   "<" @opening
   ">" @closing) @container

--- a/test/highlight/typescript/regular.ts
+++ b/test/highlight/typescript/regular.ts
@@ -29,6 +29,10 @@ class Person {
     toString(): string {
         return `${this.name} (${this.age}) (${this.salary})`; // As of version 1.4
     }
+
+    async method(): Promise<Array<Record<string, number>>> {
+        return []
+    }
 }
 
 interface Request {


### PR DESCRIPTION
This query is very useful when working with nested generics. It's about return type in added test case.