### PR TITLE
Eliminate deprecation warning for the use of for_each_child()

### DIFF
--- a/lua/ts-rainbow/internal.lua
+++ b/lua/ts-rainbow/internal.lua
@@ -92,7 +92,7 @@ function M.detach(bufnr)
 	local parser = lib.buffers[bufnr].parser
 
 	-- Clear all the namespaces for each language
-	parser:for_each_child(function(_, lang)
+	parser:children(function(_, lang)
 		lib.clear_namespace(bufnr, lang)
 	end, true)
 	-- Finally release all resources the parser is holding on to

--- a/lua/ts-rainbow/strategy/global.lua
+++ b/lua/ts-rainbow/strategy/global.lua
@@ -95,7 +95,7 @@ end
 
 ---Sets up all the callbacks and performs an initial highlighting
 local function setup_parser(bufnr, parser)
-	parser:for_each_child(function(p, lang)
+	parser:children(function(p, lang)
 		-- Skip languages which are not supported, otherwise we get a
 		-- nil-reference error
 		if not lib.get_query(lang) then return end

--- a/lua/ts-rainbow/strategy/local.lua
+++ b/lua/ts-rainbow/strategy/local.lua
@@ -165,7 +165,7 @@ end
 
 ---Sets up all the callbacks and performs an initial highlighting
 local function setup_parser(bufnr, parser)
-	parser:for_each_child(function(p, lang)
+	parser:children(function(p, lang)
 		-- Skip languages which are not supported, otherwise we get a
 		-- nil-reference error
 		if not lib.get_query(lang) then return end
@@ -204,7 +204,7 @@ function M.on_attach(bufnr, settings)
 		buffer = bufnr,
 		callback = function(args)
 			lib.clear_namespace(bufnr, parser:lang())
-			parser:for_each_child(function(_, lang)
+			parser:children(function(_, lang)
 				lib.clear_namespace(bufnr, lang)
 			end)
 			local_rainbow(args.buf, parser)


### PR DESCRIPTION
```
WARN LanguageTree:for_each_child() is deprecated, use LanguageTree:children() instead. :help deprecated
Feature will be removed in Nvim 0.11
```